### PR TITLE
Fixed "Online Only" label not showing for bestsellers.

### DIFF
--- a/blockbestsellers.php
+++ b/blockbestsellers.php
@@ -430,7 +430,7 @@ class BlockBestSellers extends Module
         SELECT
             p.id_product, IFNULL(product_attribute_shop.id_product_attribute,0) id_product_attribute, pl.`link_rewrite`, pl.`name`, pl.`description_short`, product_shop.`id_category_default`,
             image_shop.`id_image` id_image, il.`legend`,
-            ps.`quantity` AS sales, p.`ean13`, p.`upc`, cl.`link_rewrite` AS category, p.show_price, p.available_for_order, IFNULL(stock.quantity, 0) as quantity, p.customizable,
+            ps.`quantity` AS sales, p.`ean13`, p.`upc`, p.`online_only`, cl.`link_rewrite` AS category, p.show_price, p.available_for_order, IFNULL(stock.quantity, 0) as quantity, p.customizable,
             IFNULL(pa.minimal_quantity, p.minimal_quantity) as minimal_quantity, stock.out_of_stock,
             product_shop.`date_add` > "'.date('Y-m-d', strtotime('-'.(false !== Configuration::get('PS_NB_DAYS_NEW_PRODUCT') ? (int) Configuration::get('PS_NB_DAYS_NEW_PRODUCT') : 20).' DAY')).'" as new,
             product_shop.`on_sale`, product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity


### PR DESCRIPTION
Fixes the issue that "Online Only" label does not show on product items within the blockbestseller blocks.